### PR TITLE
add multi profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Wrapper options:
 - `--update-tool` checks the latest upstream version for this wrapper's CLI, rewrites the pin in the launcher repo, and rebuilds the image after confirmation
 - `--yes` skips the confirmation prompt for `--update-tool`
 - `--ssh` enables SSH agent forwarding by mounting `/run/host-services/ssh-auth.sock` and `~/.ssh/known_hosts` when available
+- `--profile NAME` (Codex only) uses a named profile with a separate `~/.codex-NAME` config directory, giving you isolated auth, state, and skills per profile
+- `--list-profiles` (Codex only) lists available Codex profiles
 - `--version` prints the installed launcher version without requiring Docker or a git repo
 - `--` passes the remaining arguments to the underlying CLI
 
@@ -139,6 +141,9 @@ Examples:
 ./dcodex --update-tool --yes
 ./dclaude --ssh
 ./dcodex --ssh
+./dcodex --profile magi
+./dcodex --profile magi --ssh
+./dcodex --list-profiles
 ```
 
 ## Folder Mount Config
@@ -236,7 +241,7 @@ Every bind mount is listed below. If the access column says `read/write`, edits 
 | `~/.claude` | `~/.claude` | Claude only | read/write | yes | Claude auth and state |
 | `~/.claude.json` | `~/.claude.json` | Claude only | read/write | yes | Claude auth file |
 | `~/.config/claude-code` | `~/.config/claude-code` | Claude only | read/write | yes | Claude CLI config |
-| `~/.codex` | `~/.codex` | Codex only | read/write | yes | Codex auth, state, and skills |
+| `~/.codex` (or `~/.codex-NAME` with `--profile`) | same path | Codex only | read/write | yes | Codex auth, state, and skills |
 | `skills/cx-navigation` in this repo | `/opt/dclaude/skills/cx-navigation` | Codex only when present | read-only | no | bundled skill template copied into `~/.codex/skills/dclaude-cx-navigation` if missing |
 | `/run/host-services/ssh-auth.sock` | same absolute path | only with `--ssh` | SSH agent socket passthrough | host agent is used directly | lets container processes authenticate through the host agent without copying keys |
 | `~/.ssh/known_hosts` | `~/.ssh/known_hosts` | only with `--ssh` when present | read-only | no | host key verification |
@@ -249,6 +254,8 @@ The launcher may also seed missing guidance into the mounted home directories:
 - `~/.claude/CLAUDE.md`
 - `~/.codex/AGENTS.md`
 - `~/.codex/skills/dclaude-cx-navigation`
+
+When using `--profile NAME`, the profile directory `~/.codex-NAME` is used instead of `~/.codex`. On first use, `AGENTS.md` and skills are copied from the default `~/.codex` if they exist there.
 
 Interactive login happens through the official CLIs inside the container. If you are not logged in yet, run the wrapper and complete the normal login flow there. The mounted state keeps you logged in across container restarts.
 
@@ -305,8 +312,8 @@ Agent `SKILL.md` integration:
 - if `~/.claude/CX.md` is missing, the launcher writes it from `cx skill`
 - if `~/.claude/CLAUDE.md` is missing, the launcher creates it with `@CX.md`
 - if `~/.claude/CLAUDE.md` exists but does not reference `@CX.md` or already contain `cx` guidance, the launcher appends `@CX.md`
-- if `~/.codex/AGENTS.md` is missing `cx` guidance, the launcher writes or appends it from `cx skill`
-- if `~/.codex/skills/dclaude-cx-navigation` is missing, the launcher seeds it from the repo template
+- if `~/.codex/AGENTS.md` is missing `cx` guidance, the launcher writes or appends it from `cx skill` (same for `~/.codex-NAME` with profiles)
+- if `~/.codex/skills/dclaude-cx-navigation` is missing, the launcher seeds it from the repo template (same for profiles)
 
 ## Rebuilds
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,6 +60,7 @@ Holds the shared launch logic:
 - common Docker flags
 - mount assembly
 - optional SSH agent forwarding
+- Codex multi-profile support (`--profile NAME`, `--list-profiles`)
 - image build bootstrap
 - `/workspace` compatibility alias setup
 
@@ -126,7 +127,7 @@ Claude-only state:
 
 Codex-only state:
 
-- `~/.codex`
+- `~/.codex` (or `~/.codex-NAME` when launched with `--profile NAME`)
 - repo-shipped `cx` skill template mounted into `/opt/dclaude/skills/cx-navigation`
 
 Optional SSH mode:
@@ -136,7 +137,7 @@ Optional SSH mode:
 
 ## Process Model
 
-The wrappers ensure one warm container per tool and target repo. They create it with `docker run -d` when missing or stale, then launch sessions with `docker exec`.
+The wrappers ensure one warm container per tool, target repo, and profile (when `--profile` is used). They create it with `docker run -d` when missing or stale, then launch sessions with `docker exec`.
 
 Warm container creation uses:
 
@@ -178,7 +179,7 @@ Container startup bootstrap:
 - reports whether `cx` is available
 - installs `bash`, `python`, and `typescript` grammars on first use
 - seeds `~/.claude/CX.md` and wires `~/.claude/CLAUDE.md` when Claude guidance is missing
-- seeds `~/.codex/AGENTS.md` and `~/.codex/skills/dclaude-cx-navigation` when Codex guidance is missing
+- seeds `~/.codex/AGENTS.md` and `~/.codex/skills/dclaude-cx-navigation` when Codex guidance is missing (or into `~/.codex-NAME` for profiles, copying from `~/.codex` on first use)
 
 Release automation:
 
@@ -198,20 +199,20 @@ None.
 There are no tables, collections, migrations, or ORM models in this project. The only stateful paths are filesystem mounts:
 
 - Claude auth/config: `~/.claude`, `~/.claude.json`, `~/.config/claude-code`
-- Codex state: `~/.codex`
+- Codex state: `~/.codex` (or `~/.codex-NAME` per profile)
 - shared caches: `~/.cache/dclaude/cx` on host mapped to `~/.cache/cx` in-container, plus `~/.cache/pip`, `~/.cache/uv`
 
 Additional non-database runtime state:
 
-- warm Docker containers named per tool and target repo
+- warm Docker containers named per tool, target repo, and profile
 - warm-container labels that track the expected runtime spec for invalidation and reuse
 
 The launcher may create missing guidance files inside those mounted directories:
 
 - `~/.claude/CX.md`
 - `~/.claude/CLAUDE.md`
-- `~/.codex/AGENTS.md`
-- `~/.codex/skills/dclaude-cx-navigation`
+- `~/.codex/AGENTS.md` (or `~/.codex-NAME/AGENTS.md` per profile)
+- `~/.codex/skills/dclaude-cx-navigation` (or `~/.codex-NAME/skills/dclaude-cx-navigation` per profile)
 
 ## Security Notes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,7 +179,8 @@ Container startup bootstrap:
 - reports whether `cx` is available
 - installs `bash`, `python`, and `typescript` grammars on first use
 - seeds `~/.claude/CX.md` and wires `~/.claude/CLAUDE.md` when Claude guidance is missing
-- seeds `~/.codex/AGENTS.md` and `~/.codex/skills/dclaude-cx-navigation` when Codex guidance is missing (or into `~/.codex-NAME` for profiles, copying from `~/.codex` on first use)
+- seeds `~/.codex/AGENTS.md` and `~/.codex/skills/dclaude-cx-navigation` when Codex guidance is missing
+- for named profiles (`~/.codex-NAME`): seeds `AGENTS.md` and `skills/dclaude-cx-navigation` from the default profile (`~/.codex`) on first use; only these specific files are copied, and only when absent in the profile dir
 
 Release automation:
 

--- a/docs/HOWRUN.md
+++ b/docs/HOWRUN.md
@@ -6,4 +6,6 @@ dclaude
 dcodex
 dclaude --ssh
 dcodex --ssh
+dcodex --profile magi        # use a named Codex profile (~/.codex-magi)
+dcodex --list-profiles        # list available Codex profiles
 ```

--- a/scripts/agent-common.sh
+++ b/scripts/agent-common.sh
@@ -208,7 +208,7 @@ sanitize_name_component() {
 
 validate_profile_name() {
   local name="$1"
-  [[ "$name" =~ ^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$ ]] || die "invalid profile name: $name (alphanumeric, hyphens, underscores only)"
+  [[ "$name" =~ ^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$ ]] || die "invalid profile name: $name (must start and end with alphanumeric; only alphanumeric, hyphens, underscores allowed)"
 }
 
 codex_home_dir() {
@@ -222,12 +222,12 @@ codex_home_dir() {
 list_profiles() {
   local dir dir_name profile_name
 
-  printf '  (default)\t%s/.codex\n' "$HOST_HOME" >&2
+  printf '  (default)\t%s/.codex\n' "$HOST_HOME"
   for dir in "$HOST_HOME"/.codex-*/; do
     [ -d "$dir" ] || continue
     dir_name="$(basename "$dir")"
     profile_name="${dir_name#.codex-}"
-    printf '  %s\t%s\n' "$profile_name" "$dir" >&2
+    printf '  %s\t%s\n' "$profile_name" "$dir"
   done
 }
 
@@ -666,12 +666,15 @@ ensure_host_state() {
       codex_home="$(codex_home_dir)"
       mkdir -p "$codex_home" "$codex_home/skills"
       if [ -n "$AGENT_PROFILE" ]; then
+        # Seed new profiles from the default profile's config (~/.codex).
+        # Only specific files are copied, and only when they don't already exist
+        # in the profile dir, to avoid clobbering profile-specific customizations.
         local default_codex="$HOST_HOME/.codex"
         if [ -f "$default_codex/AGENTS.md" ] && [ ! -f "$codex_home/AGENTS.md" ]; then
           cp "$default_codex/AGENTS.md" "$codex_home/AGENTS.md"
         fi
-        if [ -d "$default_codex/skills" ] && [ ! -d "$codex_home/skills/dclaude-cx-navigation" ]; then
-          cp -R "$default_codex/skills/." "$codex_home/skills/"
+        if [ -d "$default_codex/skills/dclaude-cx-navigation" ] && [ ! -d "$codex_home/skills/dclaude-cx-navigation" ]; then
+          cp -R "$default_codex/skills/dclaude-cx-navigation" "$codex_home/skills/dclaude-cx-navigation"
         fi
       fi
       ;;
@@ -771,6 +774,10 @@ validate_wrapper_args() {
 
   if [ "$LIST_PROFILES" -eq 1 ] && { [ "$UPDATE_TOOL" -eq 1 ] || [ "$STOP_WARM_CONTAINER" -eq 1 ] || [ "$REBUILD_IMAGE" -eq 1 ]; }; then
     die "--list-profiles cannot be combined with --update-tool, --stop, or --rebuild"
+  fi
+
+  if [ "$LIST_PROFILES" -eq 1 ] && [ -n "$AGENT_PROFILE" ]; then
+    die "--list-profiles cannot be combined with --profile"
   fi
 }
 

--- a/scripts/agent-common.sh
+++ b/scripts/agent-common.sh
@@ -28,6 +28,8 @@ RESET_WARM_CONTAINER=0
 STOP_WARM_CONTAINER=0
 UPDATE_TOOL=0
 ASSUME_YES=0
+AGENT_PROFILE=""
+LIST_PROFILES=0
 WARM_CONTAINER_NAME=""
 WARM_CONTAINER_SPEC_HASH=""
 WARM_CONTAINER_STATUS=""
@@ -45,6 +47,8 @@ Options:
   --update-tool  update the pinned upstream CLI version for this wrapper and rebuild the image
   --yes      skip the confirmation prompt for --update-tool
   --ssh      forward the host SSH agent socket and known_hosts when available
+  --profile NAME  use a named Codex profile (separate ~/.codex-NAME directory)
+  --list-profiles  list available Codex profiles
   --help     show this wrapper help
   --version  show the wrapper version
 
@@ -56,6 +60,8 @@ Examples:
   $tool --update-tool
   $tool --update-tool --yes
   $tool --ssh
+  $tool --profile magi
+  $tool --list-profiles
 EOF
 }
 
@@ -200,6 +206,31 @@ sanitize_name_component() {
   printf '%s\n' "$value"
 }
 
+validate_profile_name() {
+  local name="$1"
+  [[ "$name" =~ ^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$ ]] || die "invalid profile name: $name (alphanumeric, hyphens, underscores only)"
+}
+
+codex_home_dir() {
+  if [ -n "$AGENT_PROFILE" ]; then
+    printf '%s\n' "$HOST_HOME/.codex-$AGENT_PROFILE"
+  else
+    printf '%s\n' "$HOST_HOME/.codex"
+  fi
+}
+
+list_profiles() {
+  local dir dir_name profile_name
+
+  printf '  (default)\t%s/.codex\n' "$HOST_HOME" >&2
+  for dir in "$HOST_HOME"/.codex-*/; do
+    [ -d "$dir" ] || continue
+    dir_name="$(basename "$dir")"
+    profile_name="${dir_name#.codex-}"
+    printf '  %s\t%s\n' "$profile_name" "$dir" >&2
+  done
+}
+
 set_warm_container_name() {
   local tool="$1"
   local repo_name
@@ -207,11 +238,15 @@ set_warm_container_name() {
   local stable_identity
 
   repo_name="$(sanitize_name_component "$(basename "$TARGET_REPO_ROOT")")"
-  stable_identity="$(printf '%s\n' "$tool" "$TARGET_REPO_ROOT" "$HOST_HOME" "$HOST_UID" "$HOST_GID")"
+  stable_identity="$(printf '%s\n' "$tool" "$TARGET_REPO_ROOT" "$HOST_HOME" "$HOST_UID" "$HOST_GID" "$AGENT_PROFILE")"
   stable_hash="$(hash_string "$stable_identity")"
   stable_hash="${stable_hash:0:12}"
 
-  WARM_CONTAINER_NAME="dclaude-${tool}-${repo_name}-${stable_hash}"
+  if [ -n "$AGENT_PROFILE" ]; then
+    WARM_CONTAINER_NAME="dclaude-${tool}-${AGENT_PROFILE}-${repo_name}-${stable_hash}"
+  else
+    WARM_CONTAINER_NAME="dclaude-${tool}-${repo_name}-${stable_hash}"
+  fi
 }
 
 set_warm_container_spec_hash() {
@@ -245,6 +280,7 @@ set_warm_container_spec_hash() {
     "$HOST_UID"
     "$HOST_GID"
     "$tool"
+    "$AGENT_PROFILE"
     "$ENABLE_SSH"
     "$known_hosts_present"
     "${CX_BOOTSTRAP_LANGUAGES:-bash python typescript}"
@@ -626,7 +662,18 @@ ensure_host_state() {
       touch "$HOST_HOME/.claude.json"
       ;;
     codex)
-      mkdir -p "$HOST_HOME/.codex" "$HOST_HOME/.codex/skills"
+      local codex_home
+      codex_home="$(codex_home_dir)"
+      mkdir -p "$codex_home" "$codex_home/skills"
+      if [ -n "$AGENT_PROFILE" ]; then
+        local default_codex="$HOST_HOME/.codex"
+        if [ -f "$default_codex/AGENTS.md" ] && [ ! -f "$codex_home/AGENTS.md" ]; then
+          cp "$default_codex/AGENTS.md" "$codex_home/AGENTS.md"
+        fi
+        if [ -d "$default_codex/skills" ] && [ ! -d "$codex_home/skills/dclaude-cx-navigation" ]; then
+          cp -R "$default_codex/skills/." "$codex_home/skills/"
+        fi
+      fi
       ;;
     *)
       die "unsupported tool: $1"
@@ -683,6 +730,15 @@ parse_wrapper_args() {
       --yes)
         ASSUME_YES=1
         ;;
+      --profile)
+        shift
+        AGENT_PROFILE="${1:-}"
+        [ -n "$AGENT_PROFILE" ] || die "--profile requires a name"
+        validate_profile_name "$AGENT_PROFILE"
+        ;;
+      --list-profiles)
+        LIST_PROFILES=1
+        ;;
       --help|-h)
         usage "$WRAPPER_NAME"
         exit 0
@@ -711,6 +767,10 @@ validate_wrapper_args() {
 
   if [ "$UPDATE_TOOL" -eq 1 ] && [ "$STOP_WARM_CONTAINER" -eq 1 ]; then
     die "--update-tool cannot be combined with --stop"
+  fi
+
+  if [ "$LIST_PROFILES" -eq 1 ] && { [ "$UPDATE_TOOL" -eq 1 ] || [ "$STOP_WARM_CONTAINER" -eq 1 ] || [ "$REBUILD_IMAGE" -eq 1 ]; }; then
+    die "--list-profiles cannot be combined with --update-tool, --stop, or --rebuild"
   fi
 }
 
@@ -744,8 +804,10 @@ append_tool_mounts() {
       )
       ;;
     codex)
+      local codex_home
+      codex_home="$(codex_home_dir)"
       DOCKER_ARGS+=(
-        --mount "type=bind,src=$HOST_HOME/.codex,dst=$HOST_HOME/.codex"
+        --mount "type=bind,src=$codex_home,dst=$codex_home"
       )
       if [ -d "$TOOL_HOME/skills/cx-navigation" ]; then
         DOCKER_ARGS+=(
@@ -798,7 +860,9 @@ append_tool_env() {
       DOCKER_ARGS+=(-e "DISABLE_AUTOUPDATER=1")
       ;;
     codex)
-      DOCKER_ARGS+=(-e "CODEX_HOME=$HOST_HOME/.codex")
+      local codex_home
+      codex_home="$(codex_home_dir)"
+      DOCKER_ARGS+=(-e "CODEX_HOME=$codex_home")
       ;;
     *)
       die "unsupported tool: $1"
@@ -860,9 +924,15 @@ emit_startup_banner() {
       fi
       ;;
     codex)
-      echo "Starting interactive Codex for $TARGET_CWD" >&2
+      local codex_home
+      codex_home="$(codex_home_dir)"
+      if [ -n "$AGENT_PROFILE" ]; then
+        echo "Starting interactive Codex (profile: $AGENT_PROFILE) for $TARGET_CWD" >&2
+      else
+        echo "Starting interactive Codex for $TARGET_CWD" >&2
+      fi
       if [ "$bootstrapped_this_launch" -eq 1 ]; then
-        echo "Warm container bootstrap seeded $HOST_HOME/.codex/AGENTS.md and $HOST_HOME/.codex/skills/dclaude-cx-navigation if needed" >&2
+        echo "Warm container bootstrap seeded $codex_home/AGENTS.md and $codex_home/skills/dclaude-cx-navigation if needed" >&2
       fi
       ;;
     *)
@@ -886,8 +956,22 @@ launch_agent() {
   HOST_UID="$(id -u)"
   HOST_GID="$(id -g)"
 
+  if [ "$tool" != "codex" ]; then
+    if [ -n "$AGENT_PROFILE" ]; then
+      die "--profile is only supported for codex"
+    fi
+    if [ "$LIST_PROFILES" -eq 1 ]; then
+      die "--list-profiles is only supported for codex"
+    fi
+  fi
+
   if [ "$UPDATE_TOOL" -eq 1 ]; then
     perform_tool_update "$tool"
+    exit 0
+  fi
+
+  if [ "$LIST_PROFILES" -eq 1 ]; then
+    list_profiles
     exit 0
   fi
 

--- a/scripts/container-launch.sh
+++ b/scripts/container-launch.sh
@@ -148,7 +148,7 @@ ensure_claude_cx_guidance() {
 }
 
 ensure_codex_cx_guidance() {
-  local codex_home="$HOME/.codex"
+  local codex_home="${CODEX_HOME:-$HOME/.codex}"
   local agents_file="$codex_home/AGENTS.md"
   local skill_dir="$codex_home/skills/dclaude-cx-navigation"
 


### PR DESCRIPTION
Adds Codex **multi-profile** support to the launcher. This lets you run through multiple users on the same machine (tokenmaxxing)

It works by using different underlying `~/.codex-NAME` directories.
