### PR TITLE
POLISH: Rename mounts → read_only_mounts, ship no defaults, add git clone install path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .tmp/
 __pycache__/
+scripts/dclaude.yaml

--- a/README.md
+++ b/README.md
@@ -100,15 +100,45 @@ Some features:
 - a trusted repo
 - Docker Desktop file sharing enabled for the repo path and each configured home mount on macOS
 
-## Homebrew Install
+## Option A: Homebrew
 
 ```bash
 brew install stanislavkozlovski/tap/dclaude
 ```
 
+Optionally, configure read-only host directories the container can see:
+
+```bash
+DCLAUDE_HOME="$(dirname "$(readlink -f "$(which dclaude)")")"
+cp "$DCLAUDE_HOME/scripts/dclaude.yaml.example" "$DCLAUDE_HOME/scripts/dclaude.yaml"
+# edit dclaude.yaml to add your read-only mounts
+```
+
+## Option B: Git Clone
+
+```bash
+git clone https://github.com/stanislavkozlovski/dclaude.git ~/dclaude
+```
+
+Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
+
+```bash
+alias dclaude='~/dclaude/dclaude'
+alias dcodex='~/dclaude/dcodex'
+```
+
+Optionally, configure read-only host directories the container can see:
+
+```bash
+cp ~/dclaude/scripts/dclaude.yaml.example ~/dclaude/scripts/dclaude.yaml
+# edit dclaude.yaml to add your read-only mounts
+```
+
 # How to Run
 
 ## Quick Start
+
+The container gets **read/write** access to your current repo and **read-only** access to any directories you configure in `scripts/dclaude.yaml`. Nothing else from your host is exposed.
 
 From the repo you want to edit, run:
 
@@ -167,19 +197,25 @@ Examples:
 
 ## Folder Mount Config
 
-The launcher reads a single config file at `scripts/dclaude.yaml` in the `dclaude` repo. If no config is present, the default read-only mounts stay `~/Desktop` and `~/Downloads`.
+The launcher reads a single config file at `scripts/dclaude.yaml` in the `dclaude` repo. If no config is present, no extra host directories are mounted beyond the repo itself and shared caches.
+
+To get started, copy the example and edit it:
+
+```bash
+cp scripts/dclaude.yaml.example scripts/dclaude.yaml
+```
 
 Config shape:
 
 ```yaml
-mounts:
-  - /Desktop
-  - /Downloads
+read_only_mounts:
+  - ~/Desktop
+  - ~/Downloads
 ```
 
-Each entry is relative to `$HOME` and is bind-mounted read-only at the same absolute path inside the container. `/Desktop` becomes `$HOME/Desktop`.
+Each entry is an absolute path or starts with `~/` (resolved to `$HOME`). Entries are bind-mounted read-only at the same absolute path inside the container.
 
-Use `mounts: []` when the launcher should not expose any extra host directories beyond the repo itself and the shared caches.
+Use `read_only_mounts: []` to explicitly mount no extra directories.
 
 Configured mounts that overlap `~/.ssh` or `/run/host-services` are rejected. SSH access is only exposed through `--ssh`.
 
@@ -234,14 +270,13 @@ Deliberately omitted:
 
 The Docker build context also ignores any repo-local `.ssh` directory.
 
-Verify the Desktop and Downloads mounts are read-only with:
+Verify configured read-only mounts by trying to write to them inside the container:
 
 ```bash
-touch ~/Desktop/test
-touch ~/Downloads/test
+touch ~/Desktop/test   # should fail if ~/Desktop is in your dclaude.yaml
 ```
 
-Both commands should fail inside the container with the default config. If you override the folder config, test the paths listed in `scripts/dclaude.yaml` instead. Writing in the repo should still succeed.
+Writing in the repo should still succeed.
 
 ## Auth Persistence
 
@@ -256,7 +291,7 @@ Every bind mount is listed below. If the access column says `read/write`, edits 
 | `~/.cache/dclaude/cx` | `~/.cache/cx` | all launches | read/write | yes | `cx` cache |
 | `~/.cache/pip` | `~/.cache/pip` | all launches | read/write | yes | pip cache |
 | `~/.cache/uv` | `~/.cache/uv` | all launches | read/write | yes | uv cache |
-| configured home mounts such as `~/Desktop` and `~/Downloads` | same absolute path | all launches | read-only | no | extra host files exposed to the container |
+| configured read-only mounts from `scripts/dclaude.yaml` | same absolute path | all launches | read-only | no | extra host files exposed to the container |
 | `~/.claude` | `~/.claude` | Claude only | read/write | yes | Claude auth and state |
 | `~/.claude.json` | `~/.claude.json` | Claude only | read/write | yes | Claude auth file |
 | `~/.config/claude-code` | `~/.config/claude-code` | Claude only | read/write | yes | Claude CLI config |
@@ -290,7 +325,7 @@ Primary docs live under [`docs/`](docs/):
 - [Motivation](docs/motivation.md)
 - [License](docs/LICENSE)
 - [Version](docs/VERSION)
-- [Sample config](scripts/dclaude.yaml)
+- [Sample config](scripts/dclaude.yaml.example)
 
 ## Runtime Model
 
@@ -301,7 +336,7 @@ Every launch does the following:
 - ensures a warm per-tool container exists for that target repo
 - bind-mounts the launcher bootstrap script into the container so launcher script changes take effect on warm-container recreation
 - bind-mounts the repo read/write at its real host path
-- bind-mounts configured read-only directories at the same path, defaulting to `~/Desktop` and `~/Downloads`
+- bind-mounts configured read-only directories at the same path (none by default; see `scripts/dclaude.yaml.example`)
 - bind-mounts a persistent container-specific `cx` cache
 - runs as the current host UID/GID
 - sets `HOME` to the host home path

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ This repo provides a Dockerized wrapper around the official Claude Code and Code
 - one `docs/VERSION` file that drives image naming and releases
 - three GitHub Actions workflows for CI, scheduled tool refreshes, and tagged releases
 
-The design goal is path fidelity. The target repo and configured read-only directories are mounted into the container at the same absolute paths they have on the host. When no launcher config is present, the default mounts remain `~/Desktop` and `~/Downloads`. `/workspace` exists only as a compatibility alias.
+The design goal is path fidelity. The target repo and configured read-only directories are mounted into the container at the same absolute paths they have on the host. When no launcher config is present, no extra host directories are mounted. `/workspace` exists only as a compatibility alias.
 
 The runtime model uses two separate path roles:
 
@@ -52,7 +52,7 @@ Holds the shared launch logic:
 
 - version loading
 - separation of tool home from target repo
-- launcher-local `scripts/dclaude.yaml` loading and mount parsing
+- optional `scripts/dclaude.yaml` loading and mount parsing
 - warm container naming, spec matching, reset, and stop flows
 - image-content-aware warm-container invalidation
 - bind-mounting the live launcher bootstrap script into warm containers
@@ -64,16 +64,16 @@ Holds the shared launch logic:
 - image build bootstrap
 - `/workspace` compatibility alias setup
 
-### `scripts/dclaude.yaml`
+### `scripts/dclaude.yaml.example`
 
-Sample launcher mount config:
+Example launcher mount config (users copy to `scripts/dclaude.yaml` and uncomment):
 
-- uses a single `mounts:` list
+- uses a single `read_only_mounts:` list
 - entries are host directory paths such as `~/Desktop` or `/tmp/dclaude-share`
 - entries are bind-mounted read-only at the same absolute path inside the container
 - entries that overlap `~/.ssh` or `/run/host-services` are rejected so SSH only enters through `--ssh`
-- the checked-in sample preserves the historical `Desktop` and `Downloads` defaults
-- at runtime, the launcher reads `scripts/dclaude.yaml` from the launcher repo
+- no mounts are configured by default; the example file ships with commented-out entries
+- at runtime, the launcher reads `scripts/dclaude.yaml` from the launcher repo (if present)
 
 ### `scripts/bump_version.py`
 
@@ -116,8 +116,7 @@ Always mounted:
 
 Default folder config when no `scripts/dclaude.yaml` is present:
 
-- `~/Desktop` at the same path, read-only
-- `~/Downloads` at the same path, read-only
+- none — no extra host directories are mounted
 
 Claude-only state:
 

--- a/scripts/agent-common.sh
+++ b/scripts/agent-common.sh
@@ -21,7 +21,7 @@ read_version() {
 
 DCLAUDE_VERSION="${DCLAUDE_VERSION:-$(read_version)}"
 DCLAUDE_IMAGE_NAME="${DCLAUDE_IMAGE_NAME:-dclaude:${DCLAUDE_VERSION}}"
-DEFAULT_HOME_MOUNTS=("~/Desktop" "~/Downloads")
+DEFAULT_HOME_MOUNTS=()
 CONFIGURED_HOME_MOUNTS=("${DEFAULT_HOME_MOUNTS[@]}")
 ACTIVE_MOUNT_CONFIG=""
 RESET_WARM_CONTAINER=0
@@ -607,17 +607,17 @@ load_configured_home_mounts() {
     [ -n "$trimmed" ] || continue
 
     case "$trimmed" in
-      "mounts:")
-        [ "$saw_mounts_section" -eq 0 ] || die "duplicate mounts section in $config_path"
+      "read_only_mounts:")
+        [ "$saw_mounts_section" -eq 0 ] || die "duplicate read_only_mounts section in $config_path"
         saw_mounts_section=1
         ;;
-      "mounts: []")
-        [ "$saw_mounts_section" -eq 0 ] || die "duplicate mounts section in $config_path"
+      "read_only_mounts: []")
+        [ "$saw_mounts_section" -eq 0 ] || die "duplicate read_only_mounts section in $config_path"
         saw_mounts_section=1
         return 0
         ;;
       -\ *)
-        [ "$saw_mounts_section" -eq 1 ] || die "mount list entry found before mounts section in $config_path"
+        [ "$saw_mounts_section" -eq 1 ] || die "mount list entry found before read_only_mounts section in $config_path"
         mount_suffix="${trimmed#-}"
         mount_suffix="${mount_suffix#"${mount_suffix%%[![:space:]]*}"}"
         mount_suffix="$(normalize_home_mount_suffix "$mount_suffix" "$config_path")"
@@ -630,7 +630,7 @@ load_configured_home_mounts() {
     esac
   done < "$config_path"
 
-  [ "$saw_mounts_section" -eq 1 ] || die "missing mounts section in $config_path"
+  [ "$saw_mounts_section" -eq 1 ] || die "missing read_only_mounts section in $config_path"
 }
 
 ensure_required_paths() {

--- a/scripts/dclaude.yaml
+++ b/scripts/dclaude.yaml
@@ -1,3 +1,0 @@
-mounts:
-  - ~/Desktop
-  - ~/Downloads

--- a/scripts/dclaude.yaml.example
+++ b/scripts/dclaude.yaml.example
@@ -1,0 +1,7 @@
+# Read-only directories mounted into the container.
+# Each entry is an absolute path or starts with ~/ (resolved to $HOME).
+# Paths are bind-mounted read-only at the same absolute path inside the container.
+#
+# read_only_mounts:
+#   - ~/Desktop
+#   - ~/Downloads


### PR DESCRIPTION
This patch:
  - Renames the YAML key for whitelisted folders from `mounts` to `read_only_mounts` for clarity
  - Ship `dclaude.yaml` with commented-out entries instead of active defaults; no host directories are mounted by default
  - Add git clone + alias as a second install method alongside Homebrew in the docs
  - Quick Start now explains what the container has access to
  - Gitignore the user-created `dclaude.yaml`