### PR TITLE
chore: automate tool update PR merges

### DIFF
--- a/.github/workflows/tool-update-automerge.yml
+++ b/.github/workflows/tool-update-automerge.yml
@@ -1,0 +1,42 @@
+name: tool-update-automerge
+
+on:
+  workflow_run:
+    workflows:
+      - ci
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge_tool_update:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_branch == 'chore/tool-version-updates'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge green tool update PR
+        env:
+          GH_TOKEN: ${{ secrets.TOOL_UPDATE_TOKEN }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY"
+          test -n "$PR_NUMBER"
+          test "$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq .state)" = "OPEN"
+          test "$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" = "false"
+          test "$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)" = "chore/tool-version-updates"
+          test "$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)" = "$HEAD_SHA"
+          title="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json title --jq .title)"
+          case "$title" in
+            "chore: "*) ;;
+            *) echo "unexpected pull request title: $title" >&2; exit 1 ;;
+          esac
+          # CI is already green here; admin merge bypasses review-only branch rules for this bot branch.
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --squash --delete-branch --admin --match-head-commit "$HEAD_SHA"

--- a/.github/workflows/tool-updates.yml
+++ b/.github/workflows/tool-updates.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.TOOL_UPDATE_TOKEN }}
 
       - name: Refresh pinned tool versions
         id: refresh
@@ -45,6 +46,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.TOOL_UPDATE_TOKEN }}
           branch: chore/tool-version-updates
           delete-branch: true
           commit-message: ${{ steps.refresh.outputs.commit_message }}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ This repo provides a Dockerized wrapper around the official Claude Code and Code
 - two user-facing entrypoints: `dclaude` and `dcodex`
 - one shared shell helper for runtime assembly
 - one `docs/VERSION` file that drives image naming and releases
-- three GitHub Actions workflows for CI, scheduled tool refreshes, and tagged releases
+- four GitHub Actions workflows for CI, scheduled tool refreshes, green tool-update auto-merges, and tagged releases
 
 The design goal is path fidelity. The target repo and configured read-only directories are mounted into the container at the same absolute paths they have on the host. When no launcher config is present, no extra host directories are mounted. `/workspace` exists only as a compatibility alias.
 
@@ -99,7 +99,11 @@ Runs shell linting and smoke checks on pull requests and `main`. On successful n
 
 ### `.github/workflows/tool-updates.yml`
 
-Runs on a schedule and on manual dispatch. It refreshes pinned upstream tool versions, verifies the updated image still builds, and opens a pull request when changes are detected. The updater writes the pull request title, commit message, and body from the detected old-to-new version transitions.
+Runs on a schedule and on manual dispatch. It refreshes pinned upstream tool versions, verifies the updated image still builds, and opens a pull request when changes are detected. The updater writes the pull request title, commit message, and body from the detected old-to-new version transitions. It creates the pull request with `TOOL_UPDATE_TOKEN` so the normal pull request CI workflow runs.
+
+### `.github/workflows/tool-update-automerge.yml`
+
+Runs after the `ci` workflow completes. When CI succeeds for the `chore/tool-version-updates` branch, it verifies that the pull request head is the exact commit that passed CI, merges that pull request with `TOOL_UPDATE_TOKEN`, and deletes the branch. This makes tool-update pull requests merge on green without human review. `TOOL_UPDATE_TOKEN` must belong to an account that can push branches, open pull requests, and merge this repo; if branch rules require reviews, that account must be allowed to bypass those review rules.
 
 ### `.github/workflows/release.yml`
 
@@ -190,6 +194,7 @@ Container startup bootstrap:
 Release automation:
 
 - scheduled automation checks for newer upstream `cx`, Claude Code, and Codex releases and proposes pin updates via pull requests
+- tool-update pull requests run normal CI and merge automatically after CI passes
 - CI increments the patch version after successful pushes to `main`
 - release tags are `vX.Y.Z`
 - tag builds publish a source tarball consumed by the Homebrew tap


### PR DESCRIPTION
## Summary

- create tool-update pull requests with `TOOL_UPDATE_TOKEN` so normal pull request CI runs automatically
- add a `workflow_run` merge job that merges `chore/tool-version-updates` after `ci` succeeds
- verify the PR head SHA matches the CI run SHA before merging, then squash merge and delete the branch
- document the workflow and token requirements in `docs/ARCHITECTURE.md`

## Validation

- `git diff --check`
- `bash -n dclaude dcodex scripts/*.sh`
- `npm_config_cache=/tmp/dclaude-npm-cache npx --yes prettier --check .github/workflows/tool-updates.yml .github/workflows/tool-update-automerge.yml .github/workflows/ci.yml`