### PR TITLE
chore: claude-code 2.1.195->2.1.196

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fsSL "https://github.com/ind-igo/cx/archive/refs/tags/v${CX_VERSION}.t
 FROM python:3.12-slim
 
 ARG NODE_MAJOR=22
-ARG CLAUDE_CODE_VERSION=2.1.195
+ARG CLAUDE_CODE_VERSION=2.1.196
 ARG CODEX_VERSION=0.142.4
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ docker build -t "dclaude:$(cat docs/VERSION)" .
 
 The image currently pins the installed CLI versions:
 
-- `@anthropic-ai/claude-code@2.1.195`
+- `@anthropic-ai/claude-code@2.1.196`
 - `@openai/codex@0.142.4`
 - `cx 0.7.1`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ The launcher repo provides the image and shell assets. The target repo provides 
 
 Builds the shared runtime image on top of `python:3.12-slim`, installs Node 22, `uv`, and the official CLI packages:
 
-- `@anthropic-ai/claude-code@2.1.195`
+- `@anthropic-ai/claude-code@2.1.196`
 - `@openai/codex@0.142.4`
 - `cx 0.7.1`
 


### PR DESCRIPTION
This auto commit updates the pinned tool versions:

- `claude-code`: `2.1.195` -> `2.1.196`

It also refreshes the matching `Dockerfile`, `README.md`, and `docs/ARCHITECTURE.md` pins.

Updated by `.github/workflows/tool-updates.yml`.