### PR TITLE
chore: cx 0.7.1->0.7.2, claude-code 2.1.217->2.1.218

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 
 FROM rust:1.89-slim-bookworm AS cx-builder
 
-ARG CX_VERSION=0.7.1
-ARG CX_SHA256=dc466ee69be5b262601bce6d4cfb9810c138bb3e756e674da45c3b0b645146bf
+ARG CX_VERSION=0.7.2
+ARG CX_SHA256=24a1c0aaef2e62bbabf0a3a4eb4ca71b803ef7bd612b311e3b3418f61b45b1a4
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -23,7 +23,7 @@ RUN curl -fsSL "https://github.com/ind-igo/cx/archive/refs/tags/v${CX_VERSION}.t
 FROM python:3.12-slim
 
 ARG NODE_MAJOR=22
-ARG CLAUDE_CODE_VERSION=2.1.217
+ARG CLAUDE_CODE_VERSION=2.1.218
 ARG CODEX_VERSION=0.145.0
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -389,9 +389,9 @@ docker build -t "dclaude:$(cat docs/VERSION)" .
 
 The image currently pins the installed CLI versions:
 
-- `@anthropic-ai/claude-code@2.1.217`
+- `@anthropic-ai/claude-code@2.1.218`
 - `@openai/codex@0.145.0`
-- `cx 0.7.1`
+- `cx 0.7.2`
 
 The Codex full-access launcher was validated against `codex-cli 0.145.0`, which supports `--dangerously-bypass-approvals-and-sandbox`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,9 +25,9 @@ The launcher repo provides the image and shell assets. The target repo provides 
 
 Builds the shared runtime image on top of `python:3.12-slim`, installs Node 22, `uv`, and the official CLI packages:
 
-- `@anthropic-ai/claude-code@2.1.217`
+- `@anthropic-ai/claude-code@2.1.218`
 - `@openai/codex@0.145.0`
-- `cx 0.7.1`
+- `cx 0.7.2`
 
 The image also pre-creates `/workspace` as an alias chain that can be repointed at runtime without root privileges.
 


### PR DESCRIPTION
This auto commit updates the pinned tool versions:

- `cx`: `0.7.1` -> `0.7.2`
- `claude-code`: `2.1.217` -> `2.1.218`

It also refreshes the matching `Dockerfile`, `README.md`, and `docs/ARCHITECTURE.md` pins.

Updated by `.github/workflows/tool-updates.yml`.